### PR TITLE
bugfix/syntax-errror

### DIFF
--- a/lib/puppet/provider/postgresql_conf/ruby.rb
+++ b/lib/puppet/provider/postgresql_conf/ruby.rb
@@ -74,7 +74,7 @@ Puppet::Type.type(:postgresql_conf).provide(:ruby) do
   # check, if resource exists in postgresql.conf file
   def exists?
     select = parse_config.select { |hash| hash[:key] == resource[:key] }
-    raise ParserError, "found multiple config items of #{resource[:key]} found, please fix this" if select.length > 1
+    raise ParseError, "found multiple config items of #{resource[:key]} found, please fix this" if select.length > 1
     return false if select.empty?
 
     @result = select.first

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-postgresql",
-  "version": "10.0.2",
+  "version": "10.0.3",
   "author": "puppetlabs",
   "summary": "Offers support for basic management of PostgreSQL databases.",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary
Fix syntax error when multiple matching config items are found
`Error: /Stage[main]/Postgresql::Server::Config/Postgresql::Server::Instance::Config[main]/Postgresql::Server::Config_entry[listen_addresses_for_instance_main]/Postgresql_conf[listen_addresses_for_instance_main]: Could not evaluate: uninitialized constant ParserError
Did you mean?  ParseError`